### PR TITLE
Update build.gradle

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.readystatesoftware.systembartint:systembartint:1.0.3'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.3'
     compile 'com.github.chrisbanes.photoview:library:1.2.2'
-    compile 'com.afollestad:material-dialogs:0.7.6.0'
+    compile 'com.afollestad:material-dialogs:0.7.9.1'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.squareup.okhttp:okhttp:2.4.0'
 }


### PR DESCRIPTION
Android Studio 导入的时候显示```com.afollestad:material-dialogs:0.7.6.0```找不到，上```jcenter```看了下，并没有```0.7.6.0```版本的```material-dialogs```，更新至```0.7.9.1```之后问题解决。

http://jcenter.bintray.com/com/afollestad/material-dialogs/