### PR TITLE
Fix invalid douban url param

### DIFF
--- a/app/src/main/java/com/github/obsessive/simplifyreader/utils/UriHelper.java
+++ b/app/src/main/java/com/github/obsessive/simplifyreader/utils/UriHelper.java
@@ -114,7 +114,7 @@ public class UriHelper {
         sb.append(ApiConstants.Urls.DOUBAN_PLAY_LIST_URLS);
         sb.append("?channel=");
         sb.append(channelId);
-        sb.append("&app_name=radio_desktop_win&version=100&type=&sid=0");
+        sb.append("&app_name=radio_android&version=100&type=&sid=0");
         return sb.toString().trim();
     }
 }


### PR DESCRIPTION
问题：原来的豆瓣url已经失效，会循环播放同一首歌

修复：根据新的抓包结果，替换参数，已编译运行，验证可用