### PR TITLE
Avoid NPE when mediaPlayerDelegate is null

### DIFF
--- a/library_youku/src/main/java/com/youku/player/plugin/PluginImageAD.java
+++ b/library_youku/src/main/java/com/youku/player/plugin/PluginImageAD.java
@@ -663,9 +663,8 @@ public class PluginImageAD extends PluginOverlay implements DetailMessage {
 		} else {
 			adImageView.setOnClickListener(null);
 		}
-		if (StaticsUtil.PLAY_TYPE_LOCAL.equals(mediaPlayerDelegate.videoInfo
-				.getPlayType())
-				&& mediaPlayerDelegate != null
+		if (mediaPlayerDelegate != null
+				&& StaticsUtil.PLAY_TYPE_LOCAL.equals(mediaPlayerDelegate.videoInfo.getPlayType())
 				&& mediaPlayerDelegate.pluginManager != null) {
 			mediaPlayerDelegate.pluginManager.onVideoInfoGetted();
 			mediaPlayerDelegate.pluginManager.onChangeVideo();


### PR DESCRIPTION
If you call mediaPlayerDelegate.videoInfo before checking that mediaPlayerDelegate is not null, you'll get a NullPointerException.